### PR TITLE
Use https for THREE.js cdn

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,9 @@
 <head>
     <title>Black Hole</title>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/three.js/r78/three.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r78/three.min.js"></script>
     <script src="src/main.js"></script>
 	<script src="src/tracker.js"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.css">
     <link rel="stylesheet" href="src/style.css">
 </head>
 <body>


### PR DESCRIPTION
To fix error:

Mixed Content: The page at 'https://zongzhengli.github.io/black-hole/'
was loaded over HTTPS, but requested an insecure script
'http://cdnjs.cloudflare.com/ajax/libs/three.js/r78/three.min.js'. This
request has been blocked; the content must be served over HTTPS.